### PR TITLE
Use correct sample bit width

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -403,7 +403,7 @@ static int alsapcm_setup(alsapcm_t *self)
 	snd_pcm_hw_params_get_period_size(hwparams, &self->periodsize, &dir);
 	snd_pcm_hw_params_get_periods(hwparams, &self->periods, &dir);
 
-	self->framesize = self->channels * snd_pcm_hw_params_get_sbits(hwparams)/8;
+	self->framesize = self->channels * snd_pcm_format_physical_width(self->format)/8;
 
 	return res;
 }
@@ -598,6 +598,9 @@ alsapcm_dumpinfo(alsapcm_t *self, PyObject *args)
 	val = snd_pcm_hw_params_get_sbits(hwparams);
 	printf("significant bits = %d\n", val);
 
+	val = snd_pcm_format_physical_width(self->format);
+	printf("physical bits = %d\n", val);
+
 	val = snd_pcm_hw_params_is_batch(hwparams);
 	printf("is batch = %d\n", val);
 
@@ -776,6 +779,11 @@ alsapcm_info(alsapcm_t *self, PyObject *args)
 	val = snd_pcm_hw_params_get_sbits(hwparams);
 	value=PyLong_FromUnsignedLong((unsigned long) val);
 	PyDict_SetItemString(info,"significant_bits", value);
+	Py_DECREF(value);
+
+	val = snd_pcm_format_physical_width(self->format);
+	value=PyLong_FromUnsignedLong((unsigned long) val);
+	PyDict_SetItemString(info,"physical_bits", value);
 	Py_DECREF(value);
 
 	val = snd_pcm_hw_params_is_batch(hwparams);

--- a/doc/libalsaaudio.rst
+++ b/doc/libalsaaudio.rst
@@ -232,6 +232,7 @@ PCM objects have the following methods:
    get_periods                  *approx. periods in buffer*       integer (negative indicates error)
    rate_numden                  *numerator, denominator*          tuple (integer (Hz), integer (Hz))
    significant_bits             *significant bits in sample*      integer (negative indicates error)
+   physical_bits                *sample width in bits*            integer (negative indicates error)
    is_batch                     *hw: double buffering*            boolean (True: hardware supported)
    is_block_transfer            *hw: block transfer*              boolean (True: hardware supported)
    is_double                    *hw: double buffering*            boolean (True: hardware supported)


### PR DESCRIPTION
snd_pcm_hw_params_get_sbits gives the number of significant bits, not the actual number of bits stored. Change to snd_pcm_format_physical_width.

This fixes a bug where, for example on my hardware: format = 'S32_LE'
significant bits = 24
physical bits = 32

the program will segfault because the allocated buffer is too small.